### PR TITLE
feat(uv): use tool.uv.sources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,6 @@ build-backend = "hatchling.build"
 dev = [
     "ipython>=8.37.0",
 ]
+
+[tool.uv.sources]
+xorq = { git = "https://github.com/xorq-labs/xorq" }


### PR DESCRIPTION
to point to github latest version of xorq